### PR TITLE
Update ant build to support JitPack

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -18,7 +18,7 @@
 -->
 
 <!-- ============================================================= -->
-<project name="jGAF" default="help" basedir=".">
+<project name="jGAF" default="makedistrib" basedir=".">
 
 	<property environment="env" />
 


### PR DESCRIPTION
As suggested in #1, supporting deployment to JitPack does not involve migrating your project to maven (JitPack supports ant), but would still allow others to include your library within their maven/gradle builds.

As a reminder, JitPack performs automated builds for every new tag in your repository, using whatever your build script is (maven, ant, you name it), and expects in return that this script produces a jar file. Currently, your ant script only produces a jar file if you explicitly indicate the "makedistrib" target (see eg. https://jitpack.io/com/github/pgdurand/jGAF/v2.4.0/build.log)

This change makes "makedistrib" the default ant target, and hopefully this should suffice for JitPack to retrieve the produced jar file.
NB: the jitpack doc does not say much (if at all) about ant support, therefore I don't know where the .jar file must be located to be picked up, only one way to find out ;)